### PR TITLE
feat!(system): installer shell fix, service network updates, strap integration, add redrose-runit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ rootfs/filesystem/*bin
 rootfs/filesystem/lib*
 rootfs/filesystem/var
 rootfs/filesystem/etc/nullinitrd
+rootfs/filesystem/etc/redrose-strap

--- a/rootfs/filesystem/etc/sv/dhcp/run
+++ b/rootfs/filesystem/etc/sv/dhcp/run
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-printf "\033[96m*\033[0m Starting \033[97mdhcp\033[0m\n" > /dev/console
-
+chmod +x /etc/udhcpc/script.sh
 ip link set eth0 up
 mkdir -p /var/log/dhcp
-exec udhcpc -i eth0 -f -S 2>&1
+exec udhcpc -i eth0 -f -S -s /etc/udhcpc/script.sh &2>1

--- a/rootfs/filesystem/etc/sv/dhcp/run
+++ b/rootfs/filesystem/etc/sv/dhcp/run
@@ -3,4 +3,4 @@
 chmod +x /etc/udhcpc/script.sh
 ip link set eth0 up
 mkdir -p /var/log/dhcp
-exec udhcpc -i eth0 -f -S -s /etc/udhcpc/script.sh &2>1
+exec udhcpc -i eth0 -f -S -s /etc/udhcpc/script.sh 2>&1

--- a/rootfs/filesystem/etc/sv/hostname-reload-daemon/log/run
+++ b/rootfs/filesystem/etc/sv/hostname-reload-daemon/log/run
@@ -1,6 +1,4 @@
 #!/bin/sh
 
-printf "\033[96m*\033[0m Starting \033[97mhostname-reload-daemon\033[0m\n"
-
 mkdir -p /var/log/hostname-reload-daemon
 exec svlogd -tt /var/log/hostname-reload-daemon

--- a/rootfs/filesystem/etc/sv/hostname-reload-daemon/run
+++ b/rootfs/filesystem/etc/sv/hostname-reload-daemon/run
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-printf "\033[96m*\033[0m Starting \033[97mhostname-reload-daemon\033[0m\n"
 exec /sbin/reload-hostname-daemon

--- a/rootfs/filesystem/etc/sv/klogd/run
+++ b/rootfs/filesystem/etc/sv/klogd/run
@@ -1,4 +1,3 @@
 #!/bin/sh
-printf "\033[96m*\033[0m Starting \033[97mklogd\033[0m\n" > /dev/console
 
 exec busybox klogd -n 2>&1

--- a/rootfs/filesystem/etc/sv/mdev/run
+++ b/rootfs/filesystem/etc/sv/mdev/run
@@ -1,6 +1,4 @@
 #!/bin/sh
 
-printf "\033[96m*\033[0m Starting \033[97mmdev\033[0m\n" > /dev/console
 busybox mdev -s -S -f -d 2>&1
-
 exec sleep infinity

--- a/rootfs/filesystem/etc/sv/seed-kernel-randomness/run
+++ b/rootfs/filesystem/etc/sv/seed-kernel-randomness/run
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-printf "\033[36m*\033[0m Seeding kernel randomness\n"
 
 if [ -f /var/lib/random-seed ]; then
     cat /var/lib/random-seed > /dev/urandom

--- a/rootfs/filesystem/etc/sv/syslogd/run
+++ b/rootfs/filesystem/etc/sv/syslogd/run
@@ -1,5 +1,4 @@
 #!/bin/sh
 
-printf "\033[96m*\033[0m Starting \033[97msyslogd\033[0m\n" > /dev/console
 mkdir -p /var/log
 exec busybox syslogd -n -O /var/log/messages 2>&1

--- a/rootfs/filesystem/etc/sv/tty1/run
+++ b/rootfs/filesystem/etc/sv/tty1/run
@@ -1,6 +1,5 @@
 #!/bin/sh
 
 sleep 0.1
-printf "\033[92m*\033[0m Starting \033[97mgetty\033[0m\n"
 
 exec busybox getty -L tty1 115200 vt100 -l /bin/login

--- a/rootfs/filesystem/etc/udhcpc/script.sh
+++ b/rootfs/filesystem/etc/udhcpc/script.sh
@@ -4,7 +4,7 @@ case "$1" in
   bound|renew)
     ip addr flush dev "$interface"
     ip addr add "$ip/$mask" dev "$interface"
-    ip route add default via "$router" dev "$interface"
+    ip route replace default via "$router" dev "$interface"
     ;;
   deconfig)
     ip addr flush dev "$interface"

--- a/rootfs/filesystem/etc/udhcpc/script.sh
+++ b/rootfs/filesystem/etc/udhcpc/script.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+case "$1" in
+  bound|renew)
+    ip addr flush dev "$interface"
+    ip addr add "$ip/$mask" dev "$interface"
+    ip route add default via "$router" dev "$interface"
+    ;;
+  deconfig)
+    ip addr flush dev "$interface"
+    ip route flush dev "$interface"
+    ;;
+esac

--- a/rootfs/rootfs_strap_packages
+++ b/rootfs/rootfs_strap_packages
@@ -31,6 +31,7 @@ mkfstab
 openssl
 pcre2
 readline
+redrose-runit
 sed
 tar
 -- TODO: use full util-linux

--- a/src/installer/backend.c
+++ b/src/installer/backend.c
@@ -29,41 +29,12 @@ char* get_partition(const char* drive, int partnum) {
 }
 
 // runs when no drive found
-//
-// TODO: replace with a fork and wait for /bin/sh and create the commands in /bin
 static inline void no_drives_repl(void) {
     set_text_color(RED);
-    printf("- no drives found!\n");
+    printf("- no drives found! ");
     set_text_color(RESET);
-    printf("enter exit to remove this shell and bypass the warning. enter docs if you believe you do have a drive. otherwise, you can repair through commands.\n");
-    while (1) {
-        set_text_color(GREEN);
-        printf("\n> ");
-        set_text_color(RESET);
-        char command[4096];
-
-        if (!fgets(command, sizeof(command), stdin))
-            break;
-
-        command[strcspn(command, "\n")] = 0;
-
-        if (strcmp(command, "exit") == 0) {
-            break;
-        } else if (strcmp(command, "docs") == 0) {
-            printf("If you believe a drive is present, follow these steps:\n\n");
-
-            printf("1) Firmware / BIOS checks:\n");
-            printf("   - Reboot into firmware setup (BIOS/UEFI).\n");
-            printf("   - Ensure the drive is detected by the firmware.\n");
-            printf("   - Disable Intel RST / RAID / VMD and use AHCI mode.\n");
-            printf("   - For NVMe systems, disable VMD if enabled.\n\n");
-
-            printf("2) Virtual machines:\n");
-            printf("   - Ensure a virtual disk is attached to the VM.\n");
-        } else {
-            system(command);
-        }
-    }
+    printf("starting a recovery shell");
+    system("/bin/sh");
 }
 
 int list_devices(char *drives[64], int max) {

--- a/strap.py
+++ b/strap.py
@@ -36,6 +36,7 @@ currently_at_package = False
 version = ""
 install_to = "rootfs/filesystem"
 package = input()
+open("rootfs/filesystem/etc/redrose-strap", "a").write(package + "\n")
 if package == "":
     exit(0)
 elif package.startswith("--"):

--- a/strap.py
+++ b/strap.py
@@ -36,7 +36,8 @@ currently_at_package = False
 version = ""
 install_to = "rootfs/filesystem"
 package = input()
-open("rootfs/filesystem/etc/redrose-strap", "a").write(package + "\n")
+with open("rootfs/filesystem/etc/redrose-strap", "a", encoding="utf-8") as strap_log:
+    strap_log.write(package + "\n")
 if package == "":
     exit(0)
 elif package.startswith("--"):


### PR DESCRIPTION
- `improvement!(installer): use a real shell`
  - remove the docs command in the recovery shell; it was useless anyway
    - we might add a docs command with installation docs
    - this will improve manual installation too
  - use a real shell
- `feat!(service): ethernet, remove starting log, prepare for redrose-runit`
  - add udhcpc script
  - remove the starting logs from services which prepares for using `redrose-runit` since it prints starting services as in systemd
- feat: the system now has the strap file inside
  - store packages bootstrapped including comments (`-- as in lua`) in `/etc/redrose-strap`
- `add_package(preinstalled)!: redrose-runit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/redroselinux/redroselinux/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->